### PR TITLE
Fixed rcloneMountFlags bug

### DIFF
--- a/pkg/core/mount.go
+++ b/pkg/core/mount.go
@@ -371,7 +371,8 @@ func MountVolume(serverInstance *Server) (*exec.Cmd, chan error, string, error) 
 	}
 
 	if serverInstance.MountNewFlags != "" {
-		commandArgs = strings.Split(serverInstance.MountNewFlags, " ")
+		newFlags := strings.Split(serverInstance.MountNewFlags, " ")
+		commandArgs = append(commandArgs, newFlags...)
 	} else {
 		commandArgs = append(commandArgs, commandFlags...)
 	}


### PR DESCRIPTION
When running _sts-wire_ with _rcloneMountFlags_ option, the mount flags were passed directly to _rclone_ command and not to _rclone mount_, leading _rclone_ to crash. With the present fix, the flags are passed to _rclone mount_.